### PR TITLE
Hash router

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Home from "./components/HomeAndNavigation/Home.js";
-import { HashRouter, Route, Switch } from "react-router-dom";
+import { HashRouter, Redirect, Route, Switch } from "react-router-dom";
 import "./App.css";
 import DiceGame from "./components//Dice_Game/DiceGame";
 import Memory from "./components/Memory/Memory.js";
@@ -20,6 +20,7 @@ function App() {
           <Route path="/memory">
             <Memory />
           </Route>
+          <Redirect to="/" />
         </Switch>
       </div>
       <NavBar />

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,14 @@
-import React from 'react';
-import Home from './components/HomeAndNavigation/Home.js'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import './App.css';
-import DiceGame from './components//Dice_Game/DiceGame';
-import Memory from './components/Memory/Memory.js';
-import NavBar from './components/HomeAndNavigation/NavBar.js';
+import React from "react";
+import Home from "./components/HomeAndNavigation/Home.js";
+import { HashRouter, Route, Switch } from "react-router-dom";
+import "./App.css";
+import DiceGame from "./components//Dice_Game/DiceGame";
+import Memory from "./components/Memory/Memory.js";
+import NavBar from "./components/HomeAndNavigation/NavBar.js";
 
 function App() {
   return (
-
-    <Router>
+    <HashRouter>
       <div className="App">
         <Switch>
           <Route exact path="/">
@@ -24,8 +23,7 @@ function App() {
         </Switch>
       </div>
       <NavBar />
-    </Router>
-
+    </HashRouter>
   );
 }
 


### PR DESCRIPTION
This swaps out the BrowserRouter w/ the HashRouter.

This will make routing end up as `chetti.fun/#/dice` instead of `chetti.fun/dice`.

This should be enough if you want to share routes w/ the hash route, but if you send someone to `chetti.fun/dice` it will still 404.  

You could add some logic to the 404 page to capture/redirect if you want to solve that issue.  You could use something like this: https://github.com/rafgraph/spa-github-pages